### PR TITLE
Set pad_move=0 and use 1-based indexing for moves.

### DIFF
--- a/models/linear.py
+++ b/models/linear.py
@@ -1,14 +1,14 @@
 from torch import nn
 import torch
 
-from utils.moves import get_all_moves, NUM_OF_SQUARES, NUM_OF_PIECE_TYPES
+from utils.moves import NUM_POSSIBLE_MOVES, NUM_OF_SQUARES, NUM_OF_PIECE_TYPES
 
 
 class Linear(nn.Module):
     def __init__(self, device: torch.device | None = None, hid_scaler: int = 5) -> None:
         super().__init__()
         self.inputs = NUM_OF_SQUARES * NUM_OF_PIECE_TYPES
-        self.outputs = len(get_all_moves())
+        self.outputs = NUM_POSSIBLE_MOVES
         hidden_size = self.inputs * hid_scaler
 
         self.fc1 = nn.Linear(self.inputs, hidden_size)

--- a/models/resnet.py
+++ b/models/resnet.py
@@ -2,7 +2,7 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 
-from utils.moves import get_all_moves, NUM_OF_SQUARES
+from utils.moves import NUM_POSSIBLE_MOVES, NUM_OF_SQUARES
 
 
 def init_weights(m):
@@ -21,7 +21,7 @@ class SimpleSkipLayer(nn.Module):
     """
     def __init__(self, channels, apply_batch_norm=False):
         super().__init__()
-        self.outputs = len(get_all_moves())
+        self.outputs = NUM_POSSIBLE_MOVES
         self._apply_bnorm = apply_batch_norm
         
         self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
@@ -50,7 +50,7 @@ class ResNet(nn.Module):
     def __init__(self, device: torch.device | None = None, num_filters = 64,
                  apply_batch_norm=False) -> None:
         super().__init__()
-        self.outputs = len(get_all_moves())
+        self.outputs = NUM_POSSIBLE_MOVES
 
         self.first_conv = nn.Conv2d(12, num_filters, kernel_size=3, padding=1)
         self.res = nn.Sequential(

--- a/models/small_cnn.py
+++ b/models/small_cnn.py
@@ -1,13 +1,13 @@
 from torch import nn
 import torch
 
-from utils.moves import get_all_moves
+from utils.moves import NUM_POSSIBLE_MOVES
 
 
 class SmallCNN(nn.Module):
     def __init__(self, device: torch.device | None = None) -> None:
         super().__init__()
-        self.outputs = len(get_all_moves())
+        self.outputs = NUM_POSSIBLE_MOVES
 
         self.cnn1 = nn.Conv2d(12, 64, kernel_size=3, padding=1)
         self.activation = nn.ELU()

--- a/utils/moves.py
+++ b/utils/moves.py
@@ -8,7 +8,9 @@ NUM_OF_PIECE_TYPES = 12
 
 # Used to pad sequence of moves after the game ended for transformer training.
 PAD_BOARD = np.zeros((NUM_OF_PIECE_TYPES, 8, 8))
-PAD_MOVE = -1
+PAD_MOVE = 0
+# len(get_all_moves()) = 1794 => 1794 + 1 (for pad_move).
+NUM_POSSIBLE_MOVES = 1795
 
 
 def __flatten(xss):
@@ -47,7 +49,11 @@ def get_all_moves():
 
 
 __moves = get_all_moves()
-__moves_to_idx = {move: idx for idx, move in enumerate(__moves)}
+## Use 1-based index to leave room for zero pad index.
+__moves_to_idx = {move: idx for idx, move in enumerate(__moves, 1)}
+## Pad is not a real move. It is used to tell sequential models that the game
+## was over before the move sequence ended.
+__moves_to_idx['<pad>'] = PAD_MOVE
 
 
 def encode(move: str) -> int:
@@ -70,5 +76,8 @@ def mirror_move(uci_move: str) -> str:
 
 
 if __name__ == "__main__":
-    print(sorted(__moves))
     print(len(__moves))
+    print('### Moves:')
+    print(sorted(__moves))
+    print('### Move indices:')
+    print(__moves_to_idx)


### PR DESCRIPTION
## What:
Set pad_move=0 and use 1-based indexing for moves.

## Why:
Unfortunately, torch.nn.Embeddings does not support negative-value pad indexes. This forces our PAD_MOVE sentinel to be non-negative. This issue is a FR to allow negative pad values: <a href="https://github.com/pytorch/pytorch/issues/14844" target="_blank">link</a>.